### PR TITLE
Remove closeIssue action

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -248,8 +248,6 @@ steps:
           with: e_error.md
       - type: gate
         left: '%payload.pull_request.merged%'
-      - type: closeIssue
-        issue: Final merge conflict
       - type: getPullRequest
         action_id: pr
         pullRequest: Advanced Conflicts


### PR DESCRIPTION
This issue fixes https://github.com/github/learning-lab/issues/589 - an action attempted to close an issue that does not exist, and is not being created by the course. I'm guessing this is a remnant of old versions of the course.