### PR TITLE
Fix closeIssue bug

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -286,8 +286,6 @@ steps:
           with: e_error.md
       - type: gate
         left: '%payload.pull_request.merged%'
-      - type: closeIssue
-        issue: Next merge conflict
       - type: createIssue
         action_id: issue
         title: Next steps


### PR DESCRIPTION
Turns out we're trying to close an issue that doesn't exist, and never did exist. 

Closes https://github.com/github/learning-lab/issues/604