### PR TITLE
Remove "You enabled pages" from ending message

### DIFF
--- a/responses/05e_next-steps.md
+++ b/responses/05e_next-steps.md
@@ -13,7 +13,6 @@ Before I say good-bye, here's a recap of all the tasks you've accomplished in yo
 - You resolved a simple merge conflict
 - You created a merge conflict, and resolved it!
 - You resolved a multi-file merge conflict
-- You enabled GitHub Pages
 
 ### What's next?
 


### PR DESCRIPTION
Since we don't prompt users to enable GitHub Pages as part of the course, saying that they learned to do so during the course is no longer accurate.

cc https://github.com/github/learning-lab/issues/609